### PR TITLE
highlight call of <%def> with underscores in name

### DIFF
--- a/Syntaxes/HTML (Mako).tmLanguage
+++ b/Syntaxes/HTML (Mako).tmLanguage
@@ -467,7 +467,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(&lt;%([a-zA-Z:]+))</string>
+			<string>(&lt;%([a-zA-Z:_]+))</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -482,7 +482,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(&lt;/%\2&gt;|\/&gt;)</string>
+			<string>(&lt;/%(\2)&gt;|\/&gt;)</string>
 			<key>name</key>
 			<string>source.mako.genericcall</string>
 			<key>patterns</key>
@@ -538,7 +538,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(?=&lt;/%[a-zA-Z:]+&gt;)</string>
+					<string>(?=&lt;/%[a-zA-Z:_]+&gt;)</string>
 					<key>patterns</key>
 					<array>
 						<dict>


### PR DESCRIPTION
Also highlighting call's closing tag as "storage.type.function.python" instead of "keyword.operator"
