### PR TITLE
Fix block snippet

### DIFF
--- a/Syntaxes/HTML (Mako).tmLanguage
+++ b/Syntaxes/HTML (Mako).tmLanguage
@@ -25,7 +25,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(&lt;%) </string>
+			<string>(&lt;%\s)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Fix issue when block is not properly parsed:

```
    <%
        product_cn_data = h.get_cn_data_for_product(
            product,
            company,
            page_place,
            construct=True,
            source='portal',
        )
    %>
```