### PR TITLE
Support module-level blocks

### DIFF
--- a/Syntaxes/HTML (Mako).tmLanguage
+++ b/Syntaxes/HTML (Mako).tmLanguage
@@ -48,6 +48,29 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>(&lt;%!\s)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(%&gt;)</string>
+			<key>name</key>
+			<string>source.mako.substitution</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>source.python</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>(&lt;%(text)&gt;)</string>
 			<key>captures</key>
 			<dict>


### PR DESCRIPTION
Support syntax highlighting inside of [module-level blocks](http://docs.makotemplates.org/en/latest/syntax.html#module-level-blocks): `<%! %>`