### PR TITLE
Remove settings that break comments for regular html.

### DIFF
--- a/Preferences/HTML (Mako).tmPreferences
+++ b/Preferences/HTML (Mako).tmPreferences
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>name</key>
-    <string>Comments</string>
-    <key>scope</key>
-    <string>text.mako, text.html</string>
-    <key>settings</key>
-    <dict>
-        <key>shellVariables</key>
-        <array>
-            <dict>
-                <key>name</key>
-                <string>TM_COMMENT_START</string>
-                <key>value</key>
-                <string>## </string>
-            </dict>
-            <dict>
-                <key>name</key>
-                <string>TM_COMMENT_START_2</string>
-                <key>value</key>
-                <string>&lt;%doc&gt;</string>
-            </dict>
-            <dict>
-                <key>name</key>
-                <string>TM_COMMENT_END_2</string>
-                <key>value</key>
-                <string>&lt;/%doc&gt;</string>
-            </dict>
-        </array>
-    </dict>
-    <key>uuid</key>
-    <string>C577E524-C0DA-4BDA-8B9B-48374370BE27</string>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>text.html.mako</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>## </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_2</string>
+				<key>value</key>
+				<string>&lt;%doc&gt;</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END_2</string>
+				<key>value</key>
+				<string>&lt;/%doc&gt;</string>
+			</dict>
+		</array>
+	</dict>
+	<key>uuid</key>
+	<string>C577E524-C0DA-4BDA-8B9B-48374370BE27</string>
 </dict>
 </plist>

--- a/Syntaxes/HTML (Mako).tmLanguage
+++ b/Syntaxes/HTML (Mako).tmLanguage
@@ -5,7 +5,6 @@
 	<key>fileTypes</key>
 	<array>
 		<string>mako</string>
-		<string>html</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>(&lt;(?i:(head|table|div|style|script|ul|ol|form|dl))\b.*?&gt;|\{)</string>


### PR DESCRIPTION
I plucked this patch from ravashti's fork of the project. His patch prevents the Mako `##` comment block from being used in Markdown syntax.