### PR TITLE
Fix include

### DIFF
--- a/Syntaxes/HTML (Mako).tmLanguage
+++ b/Syntaxes/HTML (Mako).tmLanguage
@@ -190,7 +190,7 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>comment.block</string>
+					<string>comment.block.mako</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Since there is no `comment.block` defined, I'm guessing this should be `comment.block.mako`.